### PR TITLE
Fix SpriteAnimation usage

### DIFF
--- a/src/com/uwsoft/editor/renderer/factory/component/SpriteComponentFactory.java
+++ b/src/com/uwsoft/editor/renderer/factory/component/SpriteComponentFactory.java
@@ -124,11 +124,16 @@ public class SpriteComponentFactory extends ComponentFactory {
     }
 
     private Array<TextureAtlas.AtlasRegion> getRegions(String filter) {
+        // At import time, it gets renamed to spritenamePack, but
+            // region.name.contains won't match spritenamePack
+            // but it will match only spriteName, so we remove it.
+        String tmp = filter.replace("Pack", "");
+        // filtering regions by name
         // filtering regions by name
         Array<TextureAtlas.AtlasRegion> allRegions = rm.getSpriteAnimation(filter).getRegions();
         Array<TextureAtlas.AtlasRegion> regions = new Array<TextureAtlas.AtlasRegion>();
         for(TextureAtlas.AtlasRegion region: allRegions) {
-            if(region.name.contains(filter)) {
+            if(region.name.contains(tmp)) {
                 regions.add(region);
             }
         }


### PR DESCRIPTION
Importing a Sprite Animation would rename internally the atlas to **[spritename]Pack**.

Because the regions are named after the filename (without extension), a region name wouldn't contain **sprintenamePack** but it would contain **sprintename**.

This error caused an empty array to be returned, and then, you couldn't drag and drop an animation into the scene.

A quick fix of mine was to remove the **Pack** word, so it returned a correctly array of valid regions.

``` java
private Array<TextureAtlas.AtlasRegion> getRegions(String filter) {
        // At import time, it gets renamed to spritenamePack, but
            // region.name.contains won't match spritenamePack
            // but it will match only spriteName, so we remove it
        String tmp = filter.replace("Pack", "");
        // filtering regions by name
        Array<TextureAtlas.AtlasRegion> allRegions = rm.getSpriteAnimation(filter).getRegions();
        Array<TextureAtlas.AtlasRegion> regions = new Array<TextureAtlas.AtlasRegion>();
        for(TextureAtlas.AtlasRegion region: allRegions) {
            if(region.name.contains(tmp)) {
                regions.add(region);
            }
        }

        return regions;
    }
```
